### PR TITLE
fix master config file name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Access Token".
 
 You will need to provide the credentials for your app either via the command 
 line (security risk) or with a master config file (preferred).
-To create a master config file, create a file named ~/.basespace.cfg with the following content,
+To create a master config file, create a file named `~/.basespacepy.cfg` with the following content,
 filling in the clientKey, clientSecret, and accessToken (optionally appSessionId):
 <pre language="bash">
 <code>[DEFAULT]


### PR DESCRIPTION
Hi. Just fixing a minor inconsistency with the docs at <https://github.com/basespace/basespace-python-sdk> that was preventing `samples2files.py` from reading the master config file.